### PR TITLE
Updates the import example for scoped rename

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ yarn add @rpearce/simple-uniqueid
 ## Usage
 
 ```js
-import uniqueId from 'simple-uniqueid'
+import uniqueId from '@rpearce/simple-uniqueid'
 
 uniqueId() // "177dc3d88508b9f8bd2e69982a7d03b8"
 uniqueId('myPrefix-') // "myPrefix-64f8fca9b3d96c98a267ba58cf0f9eb8"


### PR DESCRIPTION
Library was renamed to `@rpearce/simple-uniqueid`. Import example in the readme shows it as `simple-uniqueid` which fails. Updates the readme to reference the correctly named library instead.